### PR TITLE
Fix message parts and attachments parsing from API response

### DIFF
--- a/client.go
+++ b/client.go
@@ -245,7 +245,7 @@ func (c *Client) GetMessage(id string) (*models.Message, error) {
 	if apiMsg.Source != "" {
 		parts, attachments, err := parseMIMEMessage(apiMsg.Source)
 		if err != nil {
-			return nil, fmt.Errorf("parsing MIME message: %w", err)
+			return nil, fmt.Errorf("parsing MIME message for ID %d: %w", apiMsg.ID, err)
 		}
 		message.Parts = parts
 		message.Attachments = attachments

--- a/client.go
+++ b/client.go
@@ -160,6 +160,16 @@ func (c *Client) ListMessages(page, perPage int) (*models.MessageList, error) {
 			Type:      apiMsg.Type,
 			Source:    apiMsg.Source,
 		}
+
+		// Parse MIME message to extract parts and attachments
+		if apiMsg.Source != "" {
+			parts, attachments, err := parseMIMEMessage(apiMsg.Source)
+			if err != nil {
+				return nil, fmt.Errorf("parsing MIME message for ID %d: %w", apiMsg.ID, err)
+			}
+			messages[i].Parts = parts
+			messages[i].Attachments = attachments
+		}
 	}
 
 	// Create message list
@@ -229,6 +239,16 @@ func (c *Client) GetMessage(id string) (*models.Message, error) {
 		Size:      apiMsg.Size,
 		Type:      apiMsg.Type,
 		Source:    apiMsg.Source,
+	}
+
+	// Parse MIME message to extract parts and attachments
+	if apiMsg.Source != "" {
+		parts, attachments, err := parseMIMEMessage(apiMsg.Source)
+		if err != nil {
+			return nil, fmt.Errorf("parsing MIME message: %w", err)
+		}
+		message.Parts = parts
+		message.Attachments = attachments
 	}
 
 	return message, nil

--- a/integration_test.go
+++ b/integration_test.go
@@ -357,6 +357,7 @@ func testEmailWithAttachment(t *testing.T, client *sendria.Client, smtpHost stri
 		"--%s\r\n"+
 		"Content-Type: text/plain; name=\"%s\"\r\n"+
 		"Content-Disposition: attachment; filename=\"%s\"\r\n"+
+		"Content-ID: <attachment123>\r\n"+
 		"Content-Transfer-Encoding: 7bit\r\n"+
 		"\r\n"+
 		"%s\r\n"+

--- a/integration_test.go
+++ b/integration_test.go
@@ -209,6 +209,42 @@ func testEmailWithHTML(t *testing.T, client *sendria.Client, smtpHost string) {
 	if plain != plainBody {
 		t.Errorf("Plain text content mismatch.\nExpected: %q\nGot: %q", plainBody, plain)
 	}
+
+	// Verify parts were parsed correctly
+	fullMsg, err := client.GetMessage(msgID)
+	if err != nil {
+		t.Fatalf("Failed to get full message: %v", err)
+	}
+
+	// Should have at least 2 parts (plain and HTML)
+	if len(fullMsg.Parts) < 2 {
+		t.Errorf("Expected at least 2 parts, got %d", len(fullMsg.Parts))
+	}
+
+	// Check if we have both text/plain and text/html parts
+	hasPlain := false
+	hasHTML := false
+	for _, part := range fullMsg.Parts {
+		if part.Type == "text/plain" {
+			hasPlain = true
+			if !strings.Contains(part.Body, "This is the plain text version") {
+				t.Errorf("Plain text part doesn't contain expected content")
+			}
+		}
+		if part.Type == "text/html" {
+			hasHTML = true
+			if !strings.Contains(part.Body, "<h1>Test Email</h1>") {
+				t.Errorf("HTML part doesn't contain expected content")
+			}
+		}
+	}
+
+	if !hasPlain {
+		t.Error("No text/plain part found")
+	}
+	if !hasHTML {
+		t.Error("No text/html part found")
+	}
 }
 
 func testEmailWithMultipleRecipients(t *testing.T, client *sendria.Client, smtpHost string) {
@@ -346,7 +382,7 @@ func testEmailWithAttachment(t *testing.T, client *sendria.Client, smtpHost stri
 
 	// Verify attachment exists
 	if len(fullMsg.Attachments) == 0 {
-		t.Skip("No attachments found - Sendria might not have parsed them")
+		t.Fatal("No attachments found - expected at least one attachment")
 	}
 
 	// Find our attachment

--- a/mime_parser.go
+++ b/mime_parser.go
@@ -1,0 +1,182 @@
+package sendria
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"mime/quotedprintable"
+	"net/mail"
+	"strings"
+
+	"github.com/enthus-golang/sendria/models"
+)
+
+// parseMIMEMessage parses the raw email source into parts and attachments
+func parseMIMEMessage(source string) ([]models.Part, []models.Attachment, error) {
+	// Parse the email message
+	msg, err := mail.ReadMessage(strings.NewReader(source))
+	if err != nil {
+		return nil, nil, fmt.Errorf("parsing email message: %w", err)
+	}
+
+	// Get content type
+	contentType := msg.Header.Get("Content-Type")
+	if contentType == "" {
+		// Simple message with no MIME parts
+		body, err := io.ReadAll(msg.Body)
+		if err != nil {
+			return nil, nil, fmt.Errorf("reading message body: %w", err)
+		}
+
+		part := models.Part{
+			Type:        "text/plain",
+			ContentType: "text/plain",
+			Body:        string(body),
+			Size:        len(body),
+		}
+
+		return []models.Part{part}, nil, nil
+	}
+
+	// Parse the content type
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return nil, nil, fmt.Errorf("parsing content type: %w", err)
+	}
+
+	var parts []models.Part
+	var attachments []models.Attachment
+
+	if strings.HasPrefix(mediaType, "multipart/") {
+		// Handle multipart messages
+		mr := multipart.NewReader(msg.Body, params["boundary"])
+		if err := parseMultipart(mr, &parts, &attachments); err != nil {
+			return nil, nil, fmt.Errorf("parsing multipart message: %w", err)
+		}
+	} else {
+		// Single part message
+		body, err := io.ReadAll(msg.Body)
+		if err != nil {
+			return nil, nil, fmt.Errorf("reading message body: %w", err)
+		}
+
+		// Decode if needed
+		encoding := msg.Header.Get("Content-Transfer-Encoding")
+		content := decodeContent(body, encoding)
+
+		part := models.Part{
+			Type:        mediaType,
+			ContentType: contentType,
+			Body:        content,
+			Size:        len(content),
+		}
+
+		parts = append(parts, part)
+	}
+
+	return parts, attachments, nil
+}
+
+// parseMultipart recursively parses multipart messages
+func parseMultipart(mr *multipart.Reader, parts *[]models.Part, attachments *[]models.Attachment) error {
+	for {
+		p, err := mr.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("reading part: %w", err)
+		}
+
+		contentType := p.Header.Get("Content-Type")
+		if contentType == "" {
+			contentType = "text/plain"
+		}
+
+		mediaType, params, err := mime.ParseMediaType(contentType)
+		if err != nil {
+			// Default to text/plain if parsing fails
+			mediaType = "text/plain"
+			params = make(map[string]string)
+		}
+
+		// Read the part content
+		partContent, err := io.ReadAll(p)
+		if err != nil {
+			return fmt.Errorf("reading part content: %w", err)
+		}
+
+		// Handle nested multipart
+		if strings.HasPrefix(mediaType, "multipart/") {
+			nestedReader := multipart.NewReader(bytes.NewReader(partContent), params["boundary"])
+			if err := parseMultipart(nestedReader, parts, attachments); err != nil {
+				return err
+			}
+			continue
+		}
+
+		// Decode content
+		encoding := p.Header.Get("Content-Transfer-Encoding")
+		decodedContent := decodeContent(partContent, encoding)
+
+		// Get content disposition
+		disposition := p.Header.Get("Content-Disposition")
+		filename := p.FileName()
+		contentID := p.Header.Get("Content-ID")
+
+		// Clean up Content-ID (remove < and >)
+		if contentID != "" {
+			contentID = strings.Trim(contentID, "<>")
+		}
+
+		// Check if it's an attachment
+		if strings.HasPrefix(disposition, "attachment") || filename != "" {
+			attachment := models.Attachment{
+				CID:         contentID,
+				Type:        mediaType,
+				Filename:    filename,
+				ContentType: contentType,
+				Size:        len(partContent),
+			}
+			*attachments = append(*attachments, attachment)
+		} else {
+			// It's a message part
+			part := models.Part{
+				Type:        mediaType,
+				ContentType: contentType,
+				Body:        decodedContent,
+				Size:        len(decodedContent),
+			}
+
+			*parts = append(*parts, part)
+		}
+	}
+
+	return nil
+}
+
+// decodeContent decodes content based on transfer encoding
+func decodeContent(content []byte, encoding string) string {
+	switch strings.ToLower(encoding) {
+	case "base64":
+		decoded, err := base64.StdEncoding.DecodeString(string(content))
+		if err != nil {
+			// Return original if decoding fails
+			return string(content)
+		}
+		return string(decoded)
+	case "quoted-printable":
+		reader := quotedprintable.NewReader(bytes.NewReader(content))
+		decoded, err := io.ReadAll(reader)
+		if err != nil {
+			// Return original if decoding fails
+			return string(content)
+		}
+		return string(decoded)
+	default:
+		return string(content)
+	}
+}

--- a/mime_parser_test.go
+++ b/mime_parser_test.go
@@ -1,0 +1,225 @@
+package sendria
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseMIMEMessage(t *testing.T) {
+	tests := []struct {
+		name             string
+		source           string
+		expectedParts    int
+		expectedAttachments int
+		checkContent     bool
+		expectedContent  string
+	}{
+		{
+			name: "simple plain text email",
+			source: `From: sender@example.com
+To: recipient@example.com
+Subject: Test Email
+Content-Type: text/plain; charset=utf-8
+
+This is a simple test email.`,
+			expectedParts:    1,
+			expectedAttachments: 0,
+			checkContent:     true,
+			expectedContent:  "This is a simple test email.",
+		},
+		{
+			name: "multipart alternative email",
+			source: `From: sender@example.com
+To: recipient@example.com
+Subject: Multipart Test
+Content-Type: multipart/alternative; boundary="boundary1"
+
+--boundary1
+Content-Type: text/plain; charset=utf-8
+
+Plain text version
+--boundary1
+Content-Type: text/html; charset=utf-8
+
+<p>HTML version</p>
+--boundary1--`,
+			expectedParts:    2,
+			expectedAttachments: 0,
+		},
+		{
+			name: "email with attachment",
+			source: `From: sender@example.com
+To: recipient@example.com
+Subject: Email with Attachment
+Content-Type: multipart/mixed; boundary="boundary2"
+
+--boundary2
+Content-Type: text/plain; charset=utf-8
+
+Email body text
+--boundary2
+Content-Type: application/pdf
+Content-Disposition: attachment; filename="document.pdf"
+Content-Transfer-Encoding: base64
+
+JVBERi0xLjQKJeLjz9MKCg==
+--boundary2--`,
+			expectedParts:    1,
+			expectedAttachments: 1,
+		},
+		{
+			name: "quoted-printable encoding",
+			source: `From: sender@example.com
+To: recipient@example.com
+Subject: Quoted Printable Test
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+Hello=20World!=0D=0AThis=20is=20a=20test.`,
+			expectedParts:    1,
+			expectedAttachments: 0,
+			checkContent:     true,
+			expectedContent:  "Hello World!\r\nThis is a test.",
+		},
+		{
+			name: "base64 encoded content",
+			source: `From: sender@example.com
+To: recipient@example.com
+Subject: Base64 Test
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: base64
+
+SGVsbG8gV29ybGQh`,
+			expectedParts:    1,
+			expectedAttachments: 0,
+			checkContent:     true,
+			expectedContent:  "Hello World!",
+		},
+		{
+			name: "nested multipart",
+			source: `From: sender@example.com
+To: recipient@example.com
+Subject: Nested Multipart
+Content-Type: multipart/mixed; boundary="outer"
+
+--outer
+Content-Type: multipart/alternative; boundary="inner"
+
+--inner
+Content-Type: text/plain
+
+Plain text
+--inner
+Content-Type: text/html
+
+<p>HTML text</p>
+--inner--
+--outer
+Content-Type: image/png
+Content-Disposition: attachment; filename="image.png"
+Content-ID: <image123>
+
+[PNG data]
+--outer--`,
+			expectedParts:    2,
+			expectedAttachments: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parts, attachments, err := parseMIMEMessage(tt.source)
+			if err != nil {
+				t.Fatalf("parseMIMEMessage() error = %v", err)
+			}
+
+			if len(parts) != tt.expectedParts {
+				t.Errorf("Expected %d parts, got %d", tt.expectedParts, len(parts))
+			}
+
+			if len(attachments) != tt.expectedAttachments {
+				t.Errorf("Expected %d attachments, got %d", tt.expectedAttachments, len(attachments))
+			}
+
+			if tt.checkContent && len(parts) > 0 {
+				if strings.TrimSpace(parts[0].Body) != strings.TrimSpace(tt.expectedContent) {
+					t.Errorf("Expected content %q, got %q", tt.expectedContent, parts[0].Body)
+				}
+			}
+		})
+	}
+}
+
+func TestParseMIMEMessage_ErrorCases(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+	}{
+		{
+			name:   "invalid email format",
+			source: "This is not a valid email",
+		},
+		{
+			name:   "empty source",
+			source: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := parseMIMEMessage(tt.source)
+			if err == nil {
+				t.Error("Expected error but got none")
+			}
+		})
+	}
+}
+
+func TestDecodeContent(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  []byte
+		encoding string
+		expected string
+	}{
+		{
+			name:     "base64 decoding",
+			content:  []byte("SGVsbG8gV29ybGQh"),
+			encoding: "base64",
+			expected: "Hello World!",
+		},
+		{
+			name:     "quoted-printable decoding",
+			content:  []byte("Hello=20World!"),
+			encoding: "quoted-printable",
+			expected: "Hello World!",
+		},
+		{
+			name:     "no encoding",
+			content:  []byte("Plain text"),
+			encoding: "",
+			expected: "Plain text",
+		},
+		{
+			name:     "unknown encoding",
+			content:  []byte("Some content"),
+			encoding: "unknown",
+			expected: "Some content",
+		},
+		{
+			name:     "invalid base64",
+			content:  []byte("Invalid!@#$"),
+			encoding: "base64",
+			expected: "Invalid!@#$", // Should return original on error
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := decodeContent(tt.content, tt.encoding)
+			if result != tt.expected {
+				t.Errorf("Expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes #6 by adding MIME parsing to extract message parts and attachments from the email source
- The Sendria API returns raw email source but doesn't parse it into structured parts/attachments
- This PR adds a MIME parser that extracts these from the source field

## Changes
- Added `mime_parser.go` with MIME parsing functionality
- Updated `GetMessage()` and `ListMessages()` to parse MIME content from source
- Added comprehensive unit tests for MIME parsing
- Updated integration tests to verify parts and attachments are correctly parsed

## Test plan
- [x] Unit tests for MIME parser with various email formats
- [x] Integration tests updated to verify parts and attachments
- [x] All existing tests pass
- [x] Linter passes with no issues

🤖 Generated with [Claude Code](https://claude.ai/code)